### PR TITLE
Feature/updates meta

### DIFF
--- a/librarian_filemanager/routes.py
+++ b/librarian_filemanager/routes.py
@@ -122,13 +122,8 @@ def show_list_view(path, view, defaults):
             data['files'] = sorted(files,
                                    key=lambda x: x.create_date, reverse=True)
         elif view != 'generic':
-            files = filter(lambda f: is_facet_valid(f.rel_path, view),
-                           data['files'])
-            facets_list = get_facets(imap(lambda f: f.rel_path, files),
-                                     facet_type=view)
-            for f, facets in izip_longest(files, facets_list):
-                f.facets = facets
-            data['files'] = files
+            data['files'] = filter(
+                lambda f: is_facet_valid(f.rel_path, view), data['files'])
     data['selected'] = selected
     return data
 

--- a/librarian_filemanager/views/filemanager/_folder.tpl
+++ b/librarian_filemanager/views/filemanager/_folder.tpl
@@ -88,7 +88,7 @@
     </li>
 </%def>
 
-<%def name="file(f, with_controls=False, is_search=False)">
+<%def name="file(f, with_controls=False, is_search=False, use_meta=False)">
     <%
         # FIXME: For some reason known only to gods of programming, the 
         # following line, which otherwise appears completely useless, **MUST** 
@@ -98,6 +98,8 @@
         apath = i18n_url('files:path', path=f.rel_path)
         parent_url = th.get_parent_url(f.rel_path)
         icon, is_thumb = th.get_file_thumb(f)
+        title = f.facets.get('title')
+        desc = f.facets.get('description')
     %>
     <li class="file-list-item file-list-file${' with-controls' if with_controls else ''}${' file-list-search-result' if is_search else ''}" role="row" aria-selected="false" tabindex>
         <a
@@ -110,12 +112,22 @@
             ${self.thumb_block(icon, 'cover' if is_thumb else 'icon')}
             <%self:file_info_inner>
                 <span class="file-list-name">
-                    ${h.to_unicode(f.name) | h}
+                    % if use_meta:
+                        ${title or h.to_unicode(f.name) | h}
+                    % else:
+                        ${h.to_unicode(f.name) | h}
+                    % endif
                 </span>
                 % if is_search and f.parent:
                     <span class="file-list-description">
                         ${_(u"in {}").format(esc(f.parent))}
                     </span>
+                % else:
+                    % if title:
+                        <span class="file-list-description">
+                            ${title | h}
+                        </span>
+                    % endif
                 % endif
             </%self:file_info_inner>
         </a>

--- a/librarian_filemanager/views/filemanager/_generic.tpl
+++ b/librarian_filemanager/views/filemanager/_generic.tpl
@@ -59,7 +59,7 @@
         ## Files
 
         % for f in files:
-            ${folder.file(f, not is_search, is_search)}
+            ${folder.file(f, with_controls=not is_search, is_search=is_search)}
         % endfor
     % endif
 </ul>

--- a/librarian_filemanager/views/filemanager/_updates.tpl
+++ b/librarian_filemanager/views/filemanager/_updates.tpl
@@ -25,7 +25,7 @@
                     <span>${th.ago(f.create_date.date(), days_only=True)}</span>
                 </h3>
             % endif
-            ${folder.file(f, True, True)}
+            ${folder.file(f, with_controls=True, is_search=True, use_meta=True)}
         % endfor
 
     % endif


### PR DESCRIPTION
Use of metadata to enhance the generic and updates tabs:
- Expand files with facets metadata in manager instead of route handler
- Show title as description in generic tab (where available)
- Show title _instead_ of file name in updates tab (where available)
