### PR TITLE
Change parent extra attribute name to parent_name

### DIFF
--- a/librarian_filemanager/manager.py
+++ b/librarian_filemanager/manager.py
@@ -59,7 +59,7 @@ class Manager(object):
     def _extend_file(self, fs_obj):
         mimetype, encoding = mimetypes.guess_type(fs_obj.rel_path)
         fs_obj.mimetype = mimetype
-        fs_obj.parent = to_unicode(
+        fs_obj.parent_name = to_unicode(
             os.path.basename(os.path.dirname(fs_obj.rel_path)))
         return fs_obj
 

--- a/librarian_filemanager/views/filemanager/_folder.tpl
+++ b/librarian_filemanager/views/filemanager/_folder.tpl
@@ -124,9 +124,9 @@
                         ${h.to_unicode(f.name) | h}
                     % endif
                 </span>
-                % if is_search and f.parent:
+                % if is_search and f.parent_name:
                     <span class="file-list-description">
-                        ${_(u"in {}").format(esc(f.parent))}
+                        ${_(u"in {}").format(esc(f.parent_name))}
                     </span>
                 % else:
                     % if title:


### PR DESCRIPTION
FSAL has a new property on it's FS objects called `parent` which return the relative path to the parent folder of an FS object, so the extra attribute `parent` added by librarian's manager will be renamed to `parent_name` from now on.
